### PR TITLE
Add word wrap to code blocks

### DIFF
--- a/huh.css
+++ b/huh.css
@@ -195,6 +195,12 @@
     font-size: 14px; }
   .huh-container--content img {
     max-width: 100%; }
+  .huh-container--content code,
+  .huh-container--content pre {
+    max-width: 100%;
+    overflow: scroll;
+    white-space: pre-wrap;
+    word-wrap: break-word; }
 
 .huh-container--close-mobile {
   cursor: pointer;

--- a/scss/_container.scss
+++ b/scss/_container.scss
@@ -122,6 +122,14 @@
 	img {
 		max-width: 100%;
 	}
+
+	code,
+	pre {
+		max-width: 100%;
+		overflow: scroll;
+		white-space: pre-wrap;
+		word-wrap: break-word;
+	}
 }
 
 .huh-container--close-mobile {


### PR DESCRIPTION
Fixes #1 by allowing words to wrap inside code blocks.

Before | After
------------ | -------------
![image](https://cloud.githubusercontent.com/assets/448298/21994599/79463602-dbee-11e6-8c3a-94388d45a61c.png) | ![image](https://cloud.githubusercontent.com/assets/448298/21994583/6cc8b5b2-dbee-11e6-8b6e-cabd06069e4d.png)