### PR TITLE
Simplify container heading text

### DIFF
--- a/huh.php
+++ b/huh.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WP_Huh {
 	public $markdown_doc_url = null;
-	
+
 	/**
 	 * Constructor.
 	 */
@@ -21,7 +21,7 @@ class WP_Huh {
 	 */
 	public function init( $markdown_doc_url ) {
 		$this->markdown_doc_url = $markdown_doc_url;
-		
+
 		if ( is_admin() || is_customize_preview() ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'huh_load_scripts' ) );
 			add_action( 'admin_footer', array( $this, 'display_huh' ) );
@@ -73,7 +73,7 @@ class WP_Huh {
 
 		<div class="huh-container" id="huh-container">
 			<div class="huh-container--head" id="huh-header">
-				<h4 class="huh-container--heading">Need help with your theme?</h4>
+				<h4 class="huh-container--heading">Need help?</h4>
 				<a href="javascript:;" class="huh-container--back" id="huh-back-to-toc">
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></g></svg>
 					Back


### PR DESCRIPTION
Shorten and simplify the container heading.

"Need help with your theme?" => "Need help?"